### PR TITLE
Update GCE image version to the latest available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 __pycache__
 *.pyc
 *.sqlite3

--- a/deploy/terraform/live/vars.tf
+++ b/deploy/terraform/live/vars.tf
@@ -34,11 +34,11 @@ variable "api_machine_config" {
 }
 
 variable "cromwell_os_image" {
-    default = "ubuntu-2004-focal-v20210325"
+  default = "ubuntu-2004-focal-v20210927"
 }
 
 variable "api_os_image" {
-    default = "ubuntu-2004-focal-v20210325"
+  default = "ubuntu-2004-focal-v20210927"
 }
 
 variable "cromwell_db_name" {


### PR DESCRIPTION
To avoid APT certificate errors:
https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
https://aws.amazon.com/premiumsupport/knowledge-center/ec2-expired-certificate/

