### PR TITLE
Upgrade Puppet to version 7 in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,8 @@ Vagrant.configure("2") do |config|
 
     # install Puppet
     CODENAME=$(/usr/bin/lsb_release -sc)
-    /usr/bin/curl -sO "https://apt.puppetlabs.com/puppet6-release-$CODENAME.deb"
-    /usr/bin/dpkg -i "puppet6-release-$CODENAME.deb"
+    /usr/bin/curl -sO "https://apt.puppetlabs.com/puppet7-release-$CODENAME.deb"
+    /usr/bin/dpkg -i "puppet7-release-$CODENAME.deb"
     /usr/bin/apt-get -qq update
     /usr/bin/apt-get -qq -y install puppet-agent
 


### PR DESCRIPTION
Puppet has already been upgraded to version 7 on GCP
