### PR TITLE
Update load balancer log prefix to match frontend log structure

### DIFF
--- a/deployment-aws/terraform/loadbalancer.tf
+++ b/deployment-aws/terraform/loadbalancer.tf
@@ -6,7 +6,7 @@ resource "aws_lb" "api" {
   security_groups = [aws_security_group.load_balancer.id]
   access_logs {
     bucket  = "webmev-logs"
-    prefix  = "${local.stack}-lb"
+    prefix  = "${local.stack}/loadbalancer"
     enabled = true
   }
 }


### PR DESCRIPTION
Proposed log structure for the `webmev-logs` bucket:
```
<stack-name>/
    cloudfront/
    loadbalancer/
    s3/
```
