### PR TITLE
Lower healthy check threshold for load balancer

### DIFF
--- a/deployment-aws/terraform/loadbalancer.tf
+++ b/deployment-aws/terraform/loadbalancer.tf
@@ -16,6 +16,9 @@ resource "aws_lb_target_group" "api" {
   port     = 80
   protocol = "HTTP"
   vpc_id   = aws_vpc.main.id
+  health_check {
+    healthy_threshold   = 2
+  }
 }
 
 resource "aws_lb_target_group_attachment" "api" {

--- a/deployment-aws/terraform/loadbalancer.tf
+++ b/deployment-aws/terraform/loadbalancer.tf
@@ -17,7 +17,7 @@ resource "aws_lb_target_group" "api" {
   protocol = "HTTP"
   vpc_id   = aws_vpc.main.id
   health_check {
-    healthy_threshold   = 2
+    healthy_threshold = 2
   }
 }
 


### PR DESCRIPTION
To help avoid extended HTTP 502 errors for new deployments
