### PR TITLE
Fix for multiple resource inputs

### DIFF
--- a/mev/api/tests/operation_test_files/valid_op_with_multiple_resource_input.json
+++ b/mev/api/tests/operation_test_files/valid_op_with_multiple_resource_input.json
@@ -1,0 +1,46 @@
+{
+    "id": "76c9b2d7-5798-4d15-beb2-c172bbede013",
+    "name": "Some name", 
+    "description": "Here is some description of the process", 
+    "inputs": {
+        "count_matrices": {
+            "description": "Some input files", 
+            "name": "Count matrices:", 
+            "required": true, 
+            "converter": "api.converters.data_resource.LocalDockerSingleDataResourceConverter",
+            "spec": {
+                "attribute_type": "VariableDataResource", 
+                "resource_types": ["I_MTX", "EXP_MTX"], 
+                "many": true
+            }
+        },
+        "p_val": {
+            "description": "The filtering threshold for the p-value", 
+            "name": "P-value threshold:", 
+            "required": false, 
+            "converter": "api.converters.basic_attributes.BoundedFloatAttributeConverter",         
+            "spec": {
+                "attribute_type": "BoundedFloat", 
+                "min": 0, 
+                "max": 1.0, 
+                "default": 0.05
+            }
+        }
+    }, 
+    "outputs": {
+        "norm_counts": {
+            "required": true,
+            "converter": "tmp",
+            "spec": {
+                "attribute_type": "DataResource", 
+                "resource_type": "EXP_MTX", 
+                "many": false
+            }
+        }
+    }, 
+    "mode": "local_docker", 
+    "repository_url": "https://github.com/myorg/myrepo.git",
+    "repository_name": "github",
+    "git_hash": "abc123",
+    "workspace_operation": true
+}

--- a/mev/api/tests/test_converters.py
+++ b/mev/api/tests/test_converters.py
@@ -730,6 +730,16 @@ class TestDataResourceConverter(BaseAPITestCase):
             mock.call(u, mock_staging_dir) for u in mock_inputs
         ])
 
+        c = LocalDockerMultipleVariableDataResourceConverter()
+        mock_convert_resource_input.reset_mock()
+        mock_convert_resource_input.side_effect = mock_paths
+        c._convert_resource_input = mock_convert_resource_input
+        x = c.convert_input( mock_inputs, '', mock_staging_dir)
+        self.assertEqual(x,  mock_paths)
+        mock_convert_resource_input.assert_has_calls([
+            mock.call(u, mock_staging_dir) for u in mock_inputs
+        ])
+
         c = LocalDockerCsvResourceConverter()
         mock_convert_resource_input.reset_mock()
         mock_convert_resource_input.side_effect = mock_paths

--- a/mev/data_structures/attribute_types.py
+++ b/mev/data_structures/attribute_types.py
@@ -380,7 +380,7 @@ class UnrestrictedStringAttribute(BaseAttributeType):
         self._value = val
 
 
-class OptionStringAttribute(BaseAttributeType):
+class BaseOptionAttribute(BaseAttributeType):
     '''
     A String type that only admits one from a set of preset options
     (e.g. like a dropdown)
@@ -392,7 +392,6 @@ class OptionStringAttribute(BaseAttributeType):
     }
     ```
     '''
-    typename = 'OptionString'
     OPTIONS_KEY = 'options'
     REQUIRED_PARAMS = [OPTIONS_KEY, ]
 
@@ -405,9 +404,9 @@ class OptionStringAttribute(BaseAttributeType):
             options = kwargs_dict.pop(self.OPTIONS_KEY)
             if type(options) == list:
                 for opt in options:
-                    if not type(opt) == str:
+                    if not type(opt) == self.BASE_TYPE:
                         raise InvalidAttributeKeywordError('The options need to be'
-                            f' strings. Failed on validating: {opt}')
+                            f' {self.READABLE_TYPE}s. Failed on validating: {opt}')
                 self._options = options
             else:
                 raise InvalidAttributeKeywordError('Need to supply a list with'
@@ -427,6 +426,60 @@ class OptionStringAttribute(BaseAttributeType):
         d = super().to_dict()
         d[self.OPTIONS_KEY] = self._options
         return d
+
+
+class OptionStringAttribute(BaseOptionAttribute):
+
+    typename = 'OptionString'
+
+    # this dictates the type that is contained
+    # in the finite set of options
+    BASE_TYPE = str
+
+    # for a human-readable exception string
+    READABLE_TYPE = 'string'
+
+
+class IntegerOptionAttribute(BaseOptionAttribute):
+    '''
+    An integer type that only admits one from a set of preset values
+    (e.g. like a dropdown)
+    ```
+    {
+        "attribute_type": "IntegerOption",
+        "value": <int>,
+        "options": [<int>, <int>,...,<int/>]
+    }
+    ```
+    '''
+    typename = 'IntegerOption'
+    # this dictates the type that is contained
+    # in the finite set of options
+    BASE_TYPE = int
+
+    # for a human-readable exception string
+    READABLE_TYPE = 'integer'
+
+
+class FloatOptionAttribute(BaseOptionAttribute):
+    '''
+    An float type that only admits one from a set of preset values
+    (e.g. like a dropdown)
+    ```
+    {
+        "attribute_type": "FloatOption",
+        "value": <int>,
+        "options": [<int>, <int>,...,<int/>]
+    }
+    ```
+    '''
+    typename = 'FloatOption'
+    # this dictates the type that is contained
+    # in the finite set of options
+    BASE_TYPE = float
+
+    # for a human-readable exception string
+    READABLE_TYPE = 'float'
 
 
 class BooleanAttribute(BaseAttributeType):

--- a/mev/data_structures/simple_attribute_factory.py
+++ b/mev/data_structures/simple_attribute_factory.py
@@ -12,6 +12,8 @@ from data_structures.attribute_types import IntegerAttribute, \
     StringAttribute, \
     UnrestrictedStringAttribute, \
     OptionStringAttribute, \
+    IntegerOptionAttribute, \
+    FloatOptionAttribute, \
     BooleanAttribute
 from data_structures.list_attributes import StringListAttribute, \
     UnrestrictedStringListAttribute, \
@@ -33,6 +35,8 @@ simple_attribute_types = [
     StringAttribute,
     UnrestrictedStringAttribute,
     OptionStringAttribute,
+    IntegerOptionAttribute,
+    FloatOptionAttribute,
     BooleanAttribute,
     DataResourceAttribute,
     OperationDataResourceAttribute,

--- a/mev/data_structures/tests/test_attributes.py
+++ b/mev/data_structures/tests/test_attributes.py
@@ -13,7 +13,9 @@ from data_structures.attribute_types import IntegerAttribute, \
     BoundedIntegerAttribute, \
     BoundedFloatAttribute, \
     BooleanAttribute, \
-    OptionStringAttribute
+    OptionStringAttribute, \
+    IntegerOptionAttribute, \
+    FloatOptionAttribute
 
 from exceptions import NullAttributeError, \
     AttributeValueError, \
@@ -459,3 +461,98 @@ class TestSimpleAttributes(unittest.TestCase):
         with self.assertRaisesRegex(InvalidAttributeKeywordError, 
             'need to be strings'):
             s = OptionStringAttribute('xyz', options=['xyz',1,'abc'])
+
+
+    def test_integer_option_attribute(self):
+
+        # test that leaving out the 'options' key causes a problem
+        with self.assertRaises(MissingAttributeKeywordError):
+            s = IntegerOptionAttribute(1)
+
+        # test that a valid spec works
+        s = IntegerOptionAttribute(10, options=[10,15])
+        self.assertEqual(s.value, 10)
+        expected_dict_representation = {
+            'attribute_type': 'IntegerOption', 
+            'value': 10, 
+            'options': [10, 15]
+        }
+        self.assertDictEqual(expected_dict_representation, s.to_dict())
+
+        # test that float or int doesn't matter for supplied value:
+        s = IntegerOptionAttribute(10.0, options=[10,20])
+
+        # test that we don't accept a float if it can't be cast to an int
+        with self.assertRaisesRegex(AttributeValueError, 'not among the valid options'):
+            s = IntegerOptionAttribute(10.5, options=[10,15])
+
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 'integers'):
+            IntegerOptionAttribute(10, options=[10,10.5])
+
+        # test null value when allowed:
+        s = IntegerOptionAttribute(None, options=[10,20], allow_null=True)
+        self.assertIsNone(s.value)
+
+        # test that exception raised if value is not in the valid options
+        with self.assertRaisesRegex(AttributeValueError, 'not among the valid options'):
+            s = IntegerOptionAttribute(-2, options=[10,15])
+
+        # test that exception raised if options are not a list
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 'list'):
+            s = IntegerOptionAttribute(10, options=10)
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 'list'):
+            s = IntegerOptionAttribute(10, options={})
+
+        # test that exception raised if value if one of the options is
+        # not a nunber. The value is valid against one of the options, but
+        # we require everything to be perfect.
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 
+            'need to be integers'):
+            s = IntegerOptionAttribute(10, options=[5,10,'abc'])
+
+    def test_float_option_attribute(self):
+
+        # test that leaving out the 'options' key causes a problem
+        with self.assertRaises(MissingAttributeKeywordError):
+            s = FloatOptionAttribute(1.0)
+
+        # test that a valid spec works
+        s = FloatOptionAttribute(10.2, options=[10.2,15.5])
+        self.assertEqual(s.value, 10.2)
+        expected_dict_representation = {
+            'attribute_type': 'FloatOption', 
+            'value': 10.2, 
+            'options': [10.2, 15.5]
+        }
+        self.assertDictEqual(expected_dict_representation, s.to_dict())
+
+        # test that float or int doesn't matter for supplied value:
+        s = FloatOptionAttribute(10.0, options=[10.0,20.0])
+
+        # test that we don't accept a float if it can't be cast to an int
+        with self.assertRaisesRegex(AttributeValueError, 'not among the valid options'):
+            s = FloatOptionAttribute(10.5, options=[10.0,15.0])
+
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 'floats'):
+            FloatOptionAttribute(10, options=[10,10.5])
+
+        # test null value when allowed:
+        s = FloatOptionAttribute(None, options=[10.5,20.2], allow_null=True)
+        self.assertIsNone(s.value)
+
+        # test that exception raised if value is not in the valid options
+        with self.assertRaisesRegex(AttributeValueError, 'not among the valid options'):
+            s = FloatOptionAttribute(2.2, options=[10.0,15.0])
+
+        # test that exception raised if options are not a list
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 'list'):
+            s = FloatOptionAttribute(10.0, options=10.0)
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 'list'):
+            s = FloatOptionAttribute(10.0, options={})
+
+        # test that exception raised if value if one of the options is
+        # not a nunber. The value is valid against one of the options, but
+        # we require everything to be perfect.
+        with self.assertRaisesRegex(InvalidAttributeKeywordError, 
+            'need to be floats'):
+            s = FloatOptionAttribute(10.5, options=[5.5,10.5,'abc'])


### PR DESCRIPTION
If a WebMeV tool requires multiple input files (e.g. SNF), then the backend was not handling the POST request payload properly. Now fixed.