### PR TITLE
adding dedicated file preview endpoint and unit tests

### DIFF
--- a/mev/api/tests/test_resource_preview.py
+++ b/mev/api/tests/test_resource_preview.py
@@ -1,11 +1,25 @@
-import unittest
+import unittest.mock as mock
 import os
+from io import BytesIO
 
 import pandas as pd
 import numpy as np
 
-from constants import TSV_FORMAT, MATRIX_KEY
+from django.urls import reverse
+from django.core.files import File
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework import status
+
+from constants import TSV_FORMAT,\
+    MATRIX_KEY,\
+    BED3_FILE_KEY,\
+    BED6_FILE_KEY,\
+    NARROWPEAK_FILE_KEY, \
+    FASTA_KEY, \
+    FASTA_FORMAT
 from resource_types import RESOURCE_MAPPING
+from resource_types.table_types import PREVIEW_NUM_LINES
 from api.models import Resource
 
 from api.tests.base import BaseAPITestCase
@@ -15,24 +29,117 @@ TESTDIR = os.path.dirname(__file__)
 TESTDIR = os.path.join(TESTDIR, 'resource_validation_test_files')
 
 
-class TestResourcePreview(BaseAPITestCase):
+class TestResourcePreviewEndpoint(BaseAPITestCase):
     '''
     Tests that the resource previews return the proper
     format.
     '''
 
+    def setUp(self):
+
+        self.establish_clients()
+
+        # get an example from the database:
+        regular_user_resources = Resource.objects.filter(
+            owner=self.regular_user_1,
+        )
+        if len(regular_user_resources) == 0:
+            msg = '''
+                Testing not setup correctly.  Please ensure that there is at least one
+                Resource instance for the user {user}
+            '''.format(user=self.regular_user_1)
+            raise ImproperlyConfigured(msg)
+        for r in regular_user_resources:
+            if r.is_active:
+                active_resource = r
+                break
+        self.resource = active_resource
+        self.url = reverse(
+            'resource-preview', 
+            kwargs={'pk': self.resource.pk}
+        )
+        for r in regular_user_resources:
+            if not r.is_active:
+                inactive_resource = r
+                break
+        self.inactive_resource_url = reverse(
+            'resource-contents', 
+            kwargs={'pk':inactive_resource.pk}
+        )
+
+    @mock.patch('api.views.resource_views.check_resource_request')
+    def test_preview_request(self, mock_check_resource_request):
+        f = os.path.join(TESTDIR, 'test_integer_matrix.tsv')
+        associate_file_with_resource(self.resource, f)
+        self.resource.resource_type = MATRIX_KEY
+        self.resource.file_format = TSV_FORMAT
+        self.resource.save()
+        mock_check_resource_request.return_value = (True, self.resource)
+        response = self.authenticated_regular_client.get(
+            self.url, format='json'
+        )
+        self.assertEqual(response.status_code, 
+            status.HTTP_200_OK)
+        j = response.json()
+        self.assertTrue(len(j) == PREVIEW_NUM_LINES)
+
+        df = pd.read_table(f, index_col=0, nrows=PREVIEW_NUM_LINES)
+        expected_rownames = df.index.tolist()
+
+        returned_rownames = [x['rowname'] for x in j]
+        self.assertCountEqual(returned_rownames, expected_rownames)
+
+        # test that we ignore params for the preview:
+        url = self.url + '?page_size=20'
+        response = self.authenticated_regular_client.get(
+            url, format='json'
+        )
+        self.assertEqual(response.status_code, 
+            status.HTTP_200_OK)
+        j = response.json()
+        self.assertTrue(len(j) == PREVIEW_NUM_LINES)
+        returned_rownames = [x['rowname'] for x in j]
+        self.assertCountEqual(returned_rownames, expected_rownames)
+
+    @mock.patch('api.views.resource_views.check_resource_request')
+    def test_preview_request_for_file_without_preview(self, mock_check_resource_request):
+        f = os.path.join(TESTDIR, 'test_integer_matrix.tsv')
+        associate_file_with_resource(self.resource, f)
+        self.resource.resource_type = FASTA_KEY
+        self.resource.file_format = FASTA_FORMAT
+        self.resource.save()
+        mock_check_resource_request.return_value = (True, self.resource)
+        response = self.authenticated_regular_client.get(
+            self.url, format='json'
+        )
+        self.assertEqual(response.status_code, 
+            status.HTTP_200_OK)
+        j = response.json()
+        self.assertTrue('Contents not available' in j['info'])
+
+
+class TestResourcePreview(BaseAPITestCase):
+
+    @mock.patch('resource_types.table_types.PREVIEW_NUM_LINES', 2)
     def test_table_preview(self):
         '''
         Tests that the returned preview has the expected format.
+
+        Note that to keep things simple, we override the default
+        value dictating the number of preview lines.
         '''
 
         columns = ['colA', 'colB', 'colC']
         rows = ['geneA', 'geneB', 'geneC']
         values = np.arange(9).reshape((3,3))
-        expected_return = [
+        full_file_return = [
             {'rowname': 'geneA', 'values': {'colA':0, 'colB':1, 'colC':2}},
             {'rowname': 'geneB', 'values': {'colA':3, 'colB':4, 'colC':5}},
             {'rowname': 'geneC', 'values': {'colA':6, 'colB':7, 'colC':8}}
+        ]
+        preview_return = [
+            {'rowname': 'geneA', 'values': {'colA':0, 'colB':1, 'colC':2}},
+            {'rowname': 'geneB', 'values': {'colA':3, 'colB':4, 'colC':5}},
         ]
         df = pd.DataFrame(values, index=rows, columns=columns)
         path = os.path.join('/tmp', 'test_preview_matrix.tsv')
@@ -46,8 +153,15 @@ class TestResourcePreview(BaseAPITestCase):
         associate_file_with_resource(r, path)
         mtx_class = RESOURCE_MAPPING[MATRIX_KEY]
         mtx_type = mtx_class()
+
+        # check that default of preview=False (no passed preview arg)
+        # returns the full 3 lines:
         contents = mtx_type.get_contents(r)
-        self.assertCountEqual(contents, expected_return)
+        self.assertCountEqual(contents, full_file_return)
+
+        # with the preview arg, check that we only get two lines back:
+        contents = mtx_type.get_contents(r, preview=True)
+        self.assertCountEqual(contents, preview_return)
         os.remove(path)
 
     def test_empty_table_preview(self):
@@ -62,3 +176,172 @@ class TestResourcePreview(BaseAPITestCase):
         mtx_type = mtx_class()
         with self.assertRaises(Exception):
             mtx_type.get_contents(path, 'tsv')
+
+    @mock.patch('resource_types.table_types.PREVIEW_NUM_LINES', 2)
+    def test_bed3_file_preview(self):
+
+        resource_path = os.path.join(TESTDIR, 'example_bed.bed')
+        r = Resource.objects.create(
+            datafile=File(BytesIO(), 'foo.tsv'),
+            name='foo.tsv',
+            resource_type=BED3_FILE_KEY,
+            file_format=TSV_FORMAT,
+            owner=get_user_model().objects.all()[0]
+        )
+        associate_file_with_resource(r, resource_path)
+
+        bed3_class = RESOURCE_MAPPING[BED3_FILE_KEY]
+        bed3_type = bed3_class()
+
+        # check that default of preview=False (no passed preview arg)
+        # returns the full 3 lines:
+        contents = bed3_type.get_contents(r)
+        full_file_return = [
+            {'rowname': 0, 'values': {'chrom':'chr1', 'start':100, 'stop':200}},
+            {'rowname': 1, 'values': {'chrom':'chr1', 'start':200, 'stop':340}},
+            {'rowname': 2, 'values': {'chrom':'chrX', 'start':100, 'stop':200}}
+        ]
+        self.assertCountEqual(contents, full_file_return)
+        # with the preview arg, check that we only get two lines back:
+        contents = bed3_type.get_contents(r, preview=True)
+        preview_return = [
+            {'rowname': 0, 'values': {'chrom':'chr1', 'start':100, 'stop':200}},
+            {'rowname': 1, 'values': {'chrom':'chr1', 'start':200, 'stop':340}}
+        ]
+        self.assertCountEqual(contents, preview_return)
+
+    @mock.patch('resource_types.table_types.PREVIEW_NUM_LINES', 2)
+    def test_bed6_file_preview(self):
+
+        resource_path = os.path.join(TESTDIR, 'bed6_example.bed')
+        r = Resource.objects.create(
+            datafile = File(BytesIO(), 'foo.tsv'),
+            name = 'foo.tsv',
+            resource_type = BED6_FILE_KEY,
+            file_format = TSV_FORMAT,
+            owner = get_user_model().objects.all()[0]
+        )
+        associate_file_with_resource(r, resource_path)
+
+        bed6_class = RESOURCE_MAPPING[BED6_FILE_KEY]
+        bed6_type = bed6_class()
+
+        # check that default of preview=False (no passed preview arg)
+        # returns the full 3 lines:
+        contents = bed6_type.get_contents(r)
+        full_file_return = [
+            {'rowname': 0, 'values': {'chrom':'chr1', 'start':100, 'stop':200, 'name':'gA', 'score': 100, 'strand': '.'}},
+            {'rowname': 1, 'values': {'chrom':'chr1', 'start':200, 'stop':340, 'name':'gB', 'score': 100, 'strand': '.'}},
+            {'rowname': 2, 'values': {'chrom':'chrX', 'start':100, 'stop':200, 'name':'gC', 'score': 100, 'strand': '.'}}
+        ]
+        self.assertCountEqual(contents, full_file_return)
+        # with the preview arg, check that we only get two lines back:
+        contents = bed6_type.get_contents(r, preview=True)
+        preview_return = [
+            {'rowname': 0, 'values': {'chrom':'chr1', 'start':100, 'stop':200, 'name':'gA', 'score': 100, 'strand': '.'}},
+            {'rowname': 1, 'values': {'chrom':'chr1', 'start':200, 'stop':340, 'name':'gB', 'score': 100, 'strand': '.'}}
+        ]
+        self.assertCountEqual(contents, preview_return)
+
+    @mock.patch('resource_types.table_types.PREVIEW_NUM_LINES', 2)
+    def test_narrowpeak_file_preview(self):
+
+        resource_path = os.path.join(TESTDIR, 'narrowpeak_example.bed')
+        r = Resource.objects.create(
+            datafile = File(BytesIO(), 'foo.tsv'),
+            name = 'foo.tsv',
+            resource_type = BED6_FILE_KEY,
+            file_format = TSV_FORMAT,
+            owner = get_user_model().objects.all()[0]
+        )
+        associate_file_with_resource(r, resource_path)
+
+        np_class = RESOURCE_MAPPING[NARROWPEAK_FILE_KEY]
+        np_type = np_class()
+
+        # check that default of preview=False (no passed preview arg)
+        # returns the full 3 lines:
+        contents = np_type.get_contents(r)
+        full_file_return = [
+            {
+                'rowname': 0, 
+                'values': {
+                    'chrom':'chr1', 
+                    'start':100, 
+                    'stop':200, 
+                    'name':'gA', 
+                    'score': 100, 
+                    'strand': '.',
+                    'signal_value': 0,
+                    'pval': 23.1,
+                    'qval': 12.43,
+                    'peak': -1
+                }
+            },
+            {
+                'rowname': 1, 
+                'values': {
+                    'chrom':'chr1', 
+                    'start':200, 
+                    'stop':340, 
+                    'name':'gB', 
+                    'score': 100, 
+                    'strand': '.',
+                    'signal_value': 0,
+                    'pval': 2.1,
+                    'qval': 0.2,
+                    'peak': -1
+                }
+            },
+            {
+                'rowname': 2, 
+                'values': {
+                    'chrom':'chrX', 
+                    'start':100, 
+                    'stop':200, 
+                    'name':'gC', 
+                    'score': 100, 
+                    'strand': '.',
+                    'signal_value': 0,
+                    'pval': 34.2,
+                    'qval': 14.2,
+                    'peak': -1
+                }
+            }
+        ]
+        self.assertCountEqual(contents, full_file_return)
+        # with the preview arg, check that we only get two lines back:
+        contents = np_type.get_contents(r, preview=True)
+        preview_return = [
+            {
+                'rowname': 0, 
+                'values': {
+                    'chrom':'chr1', 
+                    'start':100, 
+                    'stop':200, 
+                    'name':'gA', 
+                    'score': 100, 
+                    'strand': '.',
+                    'signal_value': 0,
+                    'pval': 23.1,
+                    'qval': 12.43,
+                    'peak': -1
+                }
+            },
+            {
+                'rowname': 1, 
+                'values': {
+                    'chrom':'chr1', 
+                    'start':200, 
+                    'stop':340, 
+                    'name':'gB', 
+                    'score': 100, 
+                    'strand': '.',
+                    'signal_value': 0,
+                    'pval': 2.1,
+                    'qval': 0.2,
+                    'peak': -1
+                }
+            }
+        ]
+        self.assertCountEqual(contents, preview_return)

--- a/mev/api/tests/test_resource_utils.py
+++ b/mev/api/tests/test_resource_utils.py
@@ -230,7 +230,7 @@ class TestResourceUtilities(BaseAPITestCase):
         expected_dict = {'a': 1, 'b':2}
 
         class mock_resource_type_class(object):
-            def get_contents(self, resource, query_params={}):
+            def get_contents(self, resource, query_params={}, preview=False):
                 return expected_dict
 
         mock_resource_mapping.__getitem__.return_value = mock_resource_type_class

--- a/mev/api/urls.py
+++ b/mev/api/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path('resources/', api.views.ResourceList.as_view(), name='resource-list'),
     path('resources/<uuid:pk>/', api.views.ResourceDetail.as_view(), name='resource-detail'),
     path('resources/<uuid:pk>/contents/', api.views.ResourceContents.as_view(), name='resource-contents'),
+    path('resources/<uuid:pk>/contents/preview/', api.views.ResourcePreview.as_view(), name='resource-preview'),
     path('resources/<uuid:pk>/contents/transform/', api.views.ResourceContentTransform.as_view(), name='resource-contents-transform'),
     path('resources/add-bucket-resources/', api.views.AddBucketResourceView.as_view(), name='bucket-resource-add'),
     path('resources/<uuid:pk>/metadata/', api.views.ResourceMetadataView.as_view(), name='resource-metadata-detail'),

--- a/mev/api/utilities/resource_utilities.py
+++ b/mev/api/utilities/resource_utilities.py
@@ -121,12 +121,14 @@ def set_resource_to_inactive(resource_instance):
     resource_instance.save()
 
 
-def get_resource_view(resource_instance, query_params={}):
+def get_resource_view(resource_instance, query_params={}, preview=False):
     '''
     Returns a "view" of the resource_instance in JSON-format.
 
     Only valid for certain resource types and assumes
     that the resource is active. 
+
+    If preview=True, only retrieve a subset of the data
     '''
     logger.info('Retrieving data view for resource: {resource}.'.format(
         resource=resource_instance
@@ -141,7 +143,7 @@ def get_resource_view(resource_instance, query_params={}):
         # prevents us from pulling remote resources if we can't view the contents anyway
         return None
     else:
-        return get_contents(resource_instance, query_params)
+        return get_contents(resource_instance, query_params, preview=preview)
 
 def get_resource_paginator(resource_type):
     '''

--- a/mev/api/views/__init__.py
+++ b/mev/api/views/__init__.py
@@ -12,6 +12,7 @@ from .workspace_views import WorkspaceList, WorkspaceDetail
 from .resource_views import ResourceList, \
     ResourceDetail, \
     ResourceContents, \
+    ResourcePreview, \
     AddBucketResourceView, \
     ResourceContentTransform
 from .resource_download import ResourceDownload, \

--- a/mev/api/views/resource_views.py
+++ b/mev/api/views/resource_views.py
@@ -209,6 +209,48 @@ class ResourceContents(APIView):
             else:
                 return Response(contents)
 
+
+class ResourcePreview(APIView):
+    '''
+    Returns a preview of the data underlying a Resource.
+
+    Depending on the data, the format of the response may be different.
+    Additionally, some Resource types do not support a preview.
+    
+    This returns a JSON-format representation of the data.
+
+    This endpoint is only really sensible for certain types of 
+    Resources, such as those in table format.  Other types, such as 
+    sequence-based files do not have this functionality.
+    '''
+
+    def get(self, request, *args, **kwargs):
+        user = request.user
+        resource_pk = kwargs['pk']
+
+        valid_request, r = check_resource_request(user, resource_pk)
+        if not valid_request:
+            # if the request was not valid, then `r` is a Response object.
+            return r
+
+        # requester can access, resource is active.  Go get contents
+        try:
+            contents = get_resource_view(r, {}, preview=True)
+        except Exception as ex:
+            return Response(
+                {'error': 'Experienced an issue when preparing'
+                          f' the resource preview: {ex}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )   
+        if contents is None:
+            return Response(
+                {'info': 'Contents not available for this resource.'},
+                status=status.HTTP_200_OK
+            )
+        else:
+            return Response(contents)
+
+
 class AddBucketResourceView(APIView):
     '''
     This view is used to create a new user-associated resource given

--- a/mev/resource_types/__init__.py
+++ b/mev/resource_types/__init__.py
@@ -127,7 +127,8 @@ def get_standard_format(resource_type_str):
     rtc = get_resource_type_instance(resource_type_str)
     return rtc.STANDARD_FORMAT
 
-def get_contents(resource_instance, query_params={}):
+
+def get_contents(resource_instance, query_params={}, preview=False):
     '''
     Returns a "view" of the data underlying a Resource. The actual
     implementation of that view is prepared by the class corresponding
@@ -137,6 +138,8 @@ def get_contents(resource_instance, query_params={}):
     bracketed indexing (e.g. x[10:24]) and len() (and possibly other methods).
     We use the django.core.paginator.Paginator class, which expects 'list-like'
     arguments to be provided.
+
+    If preview=True, then a small subset of the data is returned
     '''
 
     # The resource type is the shorthand identifier.
@@ -152,7 +155,8 @@ def get_contents(resource_instance, query_params={}):
         
     # instantiate the proper class for this type:
     resource_type = resource_class()
-    return resource_type.get_contents(resource_instance, query_params)
+    return resource_type.get_contents(resource_instance, query_params, preview=preview)
+
 
 def get_resource_paginator(resource_type_str):
     '''

--- a/mev/resource_types/base.py
+++ b/mev/resource_types/base.py
@@ -28,7 +28,7 @@ class DataResource(object):
         return False
 
 
-    def get_contents(self, resource_instance, query_params={}):
+    def get_contents(self, resource_instance, query_params={}, preview=False):
         raise NotImplementedError('You must'
         ' implement this method in the derived class')
 

--- a/mev/resource_types/general_types.py
+++ b/mev/resource_types/general_types.py
@@ -34,6 +34,6 @@ class GeneralResource(DataResource):
         return self.metadata
 
 
-    def get_contents(self, resource_instance, query_params={}):
+    def get_contents(self, resource_instance, query_params={}, preview=False):
         logger.info('Cannot use get_contents on an unknown type.')
         return None

--- a/mev/resource_types/json_types.py
+++ b/mev/resource_types/json_types.py
@@ -138,8 +138,7 @@ class JsonResource(DataResource):
             self.metadata[PARENT_OP_KEY] = parent_op_pk
         return self.metadata
 
-
-    def get_contents(self, resource_instance, query_params={}):
+    def get_contents(self, resource_instance, query_params={}, preview=False):
 
         # since the pagination query params are among the general query parameters, we DON'T
         # want to pass them to the filtering.


### PR DESCRIPTION
File previews obtained from current strategy (using GET params) requires loading of the whole file, which performs poorly for large data. Dedicated endpoint uses a file reading method that avoids the full load.