### PR TITLE
Upgrade Puppet to version 8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,9 +13,10 @@ Vagrant.configure("2") do |config|
     set -x
 
     # install Puppet
-    CODENAME=$(/usr/bin/lsb_release -sc)
-    /usr/bin/curl -sO "https://apt.puppetlabs.com/puppet7-release-$CODENAME.deb"
-    /usr/bin/dpkg -i "puppet7-release-$CODENAME.deb"
+    OS_CODENAME=$(/usr/bin/lsb_release -sc)
+    PUPPET_PACKAGE=puppet8-release-${OS_CODENAME}.deb
+    /usr/bin/curl -sO "https://apt.puppetlabs.com/${PUPPET_PACKAGE}"
+    /usr/bin/dpkg -i "$PUPPET_PACKAGE"
     /usr/bin/apt-get -qq update
     /usr/bin/apt-get -qq -y install puppet-agent
 

--- a/deployment-aws/terraform/apiserver.tf
+++ b/deployment-aws/terraform/apiserver.tf
@@ -146,9 +146,10 @@ resource "aws_instance" "api" {
   /usr/bin/hostnamectl set-hostname ${local.backend_cname}
 
   # install Puppet
-  CODENAME=$(/usr/bin/lsb_release -sc)
-  /usr/bin/curl -sO "https://apt.puppetlabs.com/puppet7-release-$CODENAME.deb"
-  /usr/bin/dpkg -i "puppet7-release-$CODENAME.deb"
+  OS_CODENAME=$(/usr/bin/lsb_release -sc)
+  PUPPET_PACKAGE=puppet8-release-$${OS_CODENAME}.deb
+  /usr/bin/curl -sO "https://apt.puppetlabs.com/$${PUPPET_PACKAGE}"
+  /usr/bin/dpkg -i "$PUPPET_PACKAGE"
   /usr/bin/apt-get -qq update
   /usr/bin/apt-get -qq -y install puppet-agent nvme-cli
 

--- a/deployment-aws/terraform/cromwell.tf
+++ b/deployment-aws/terraform/cromwell.tf
@@ -171,8 +171,9 @@ resource "aws_instance" "cromwell" {
 
   # install Puppet
   CODENAME=$(/usr/bin/lsb_release -sc)
-  /usr/bin/curl -sO "https://apt.puppetlabs.com/puppet7-release-$CODENAME.deb"
-  /usr/bin/dpkg -i "puppet7-release-$CODENAME.deb"
+  PUPPET_PACKAGE=puppet8-release-$${OS_CODENAME}.deb
+  /usr/bin/curl -sO "https://apt.puppetlabs.com/$${PUPPET_PACKAGE}"
+  /usr/bin/dpkg -i "$PUPPET_PACKAGE"
   /usr/bin/apt-get -qq update
   /usr/bin/apt-get -qq -y install puppet-agent
 


### PR DESCRIPTION
This was prompted by the following error message during provisioning:
```
    api: ++ /opt/puppetlabs/puppet/bin/gem install librarian-puppet -v 5.0.0 --no-document
    api: ERROR:  Error installing librarian-puppet:
    api: 	The last version of faraday-net_http (>= 2.0, < 3.2) to support your Ruby & RubyGems was 3.0.2. Try installing it with `gem install faraday-net_http -v 3.0.2` and then running the current command again
    api: 	faraday-net_http requires Ruby version >= 3.0.0. The current ruby version is 2.7.8.225.
```
